### PR TITLE
Route53

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -43,6 +43,24 @@ provider "registry.terraform.io/equinix/metal" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.64.2"
+  hashes = [
+    "h1:eXusrZ56Ye4gprLzI3dXBy50DV+sbY5gOoJ7cNuouzA=",
+    "zh:0b029a2282beabfe410eb2969e18ca773d3473415e442be4dc8ce0eb6d1cd8c5",
+    "zh:3209de3266a1138f1ccb09f094fdd98b6f55afc06e291db0abe092ec5dbe7640",
+    "zh:40648266551631cbc15f8a76e80faf300510e3b38c2544d43fc25e37e6802727",
+    "zh:483c8af92ae70146f2790a70c1a810251e7135aa912b66e769c934eddceebe32",
+    "zh:4d106d8d415d8df342f3f85e58c35418e6c55e3cb7f02897f832cefac4dca68c",
+    "zh:972626a6ddb31d5216606d12ab5c30fbf8d51ed2bbe0efcdd7cffa68c1141557",
+    "zh:a230d55ec52b1695148d40296877ee23e0b302e817154f9b838eb117c87b13fa",
+    "zh:c95fddfbd7f870db949da0601323e866e0f0fb0d4a93e96725ae5b88029e84d5",
+    "zh:ea0c7f568074f835f22273c8e7e61e87f5277e32004c72122915fd3c8df49ccc",
+    "zh:f96d25887e6e2d2ae47659e2c586efea2167995b59a479ae65a02b097da86474",
+    "zh:fe7502d8e52d3b5ccb2b3c178e7ea894344783093aa71ffb20e978914c976182",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/external" {
   version = "2.1.0"
   hashes = [

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cd terraform-metal-openshift
 
 1. [Obtain an OpenShift Cluster Manager API Token](https://cloud.redhat.com/openshift/token) for pullSecret generation.
 
-1. Configure TF_VARs applicable to your Equinix Metal project, Cloudflare zone, and OpenShift API Token:
+1. Configure TF_VARs applicable to your Equinix Metal project, DNS settings, and OpenShift API Token:
 
     ```bash
     export TF_VAR_project_id="kajs886-l59-8488-19910kj"
@@ -70,8 +70,8 @@ cd terraform-metal-openshift
 
     export TF_VAR_cluster_basedomain="domain.com"
     export TF_VAR_ocp_cluster_manager_token="eyJhbGc...d8Agva"
-    export TF_VAR_dns_provider = "cloudflare"
-    export TF_VAR_dns_options = {"api_token": "abc..."}
+    export TF_VAR_dns_provider = "cloudflare" # aws and linode are also supported
+    export TF_VAR_dns_options = {"api_token": "abc..."} # needed for aws and linode
     ```
 
 1. Initialize and validate terraform:

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -2,7 +2,6 @@
 // provider definitions to this layer and assume that an invalid token for the
 // unused provider will not prevent the needed provider from succeeding.
 
-
 provider "cloudflare" {
   api_token = try(var.dns_options.api_token, "")
   api_key   = try(var.dns_options.api_key, null)
@@ -11,6 +10,20 @@ provider "cloudflare" {
 
 provider "linode" {
   token = try(var.dns_options.api_token, "")
+}
+
+provider "aws" {
+  region = "us-east-1" # doesn't matter
+}
+
+module "aws" {
+  count  = (var.dns_provider == "aws") ? 1 : 0
+  source = "./modules/aws"
+
+  node_type          = var.node_type
+  cluster_name       = var.cluster_name
+  cluster_basedomain = var.cluster_basedomain
+  node_ips           = var.node_ips
 }
 
 module "cloudflare" {

--- a/modules/dns/modules/aws/main.tf
+++ b/modules/dns/modules/aws/main.tf
@@ -1,0 +1,56 @@
+locals {
+  basedomain = replace(var.cluster_basedomain, "${var.cluster_name}.", "")
+}
+data "aws_route53_zone" "basedomain" {
+  name = local.basedomain
+}
+
+resource "aws_route53_record" "dns_a_cluster_api" {
+  zone_id = data.aws_route53_zone.basedomain.id
+  type    = "A"
+  name    = "api.${var.cluster_name}"
+  records = var.node_ips
+  count   = (var.node_type == "lb" ? 1 : 0)
+}
+
+resource "aws_route53_record" "dns_a_cluster_api_int" {
+  zone_id = data.aws_route53_zone.basedomain.id
+  type    = "A"
+  name    = "api-int.${var.cluster_name}"
+  records = var.node_ips
+  count   = (var.node_type == "lb" ? 1 : 0)
+}
+
+resource "aws_route53_record" "dns_a_cluster_wildcard_https" {
+  zone_id = data.aws_route53_zone.basedomain.id
+  type    = "A"
+  name    = "*.apps.${var.cluster_name}"
+  records = var.node_ips
+  count   = (var.node_type == "lb" ? 1 : 0)
+}
+
+resource "aws_route53_record" "dns_a_node" {
+  zone_id = data.aws_route53_zone.basedomain.id
+  type    = "A"
+  name    = "${var.node_type}-${count.index}.${var.cluster_name}"
+  records = var.node_ips
+  count   = length(var.node_ips)
+}
+
+resource "aws_route53_record" "dns_a_etcd" {
+  zone_id = data.aws_route53_zone.basedomain.id
+  type    = "A"
+  name    = "etcd-${count.index}.${var.cluster_name}"
+  records = var.node_ips
+  count   = (var.node_type == "master" ? len(var.node_ips) : 0)
+}
+
+resource "aws_route53_record" "dns_srv_etcd" {
+  zone_id = data.aws_route53_zone.basedomain.id
+  type    = "SRV"
+  name    = "_etcd-server-ssl._tcp"
+
+  records = [for i, addr in var.node_ips : "0 10 2380 ${addr}."]
+  count   = (var.node_type == "master" ? len(var.node_ips) : 0)
+}
+

--- a/modules/dns/modules/aws/variables.tf
+++ b/modules/dns/modules/aws/variables.tf
@@ -1,0 +1,7 @@
+variable "node_type" {}
+variable "cluster_name" {}
+variable "cluster_basedomain" {}
+variable "node_ips" {
+  type = list(any)
+}
+

--- a/modules/dns/modules/aws/versions.tf
+++ b/modules/dns/modules/aws/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #3 (Adds AWS Route53 support)

- [ ] Do we need to expose additional variables for AWS provider configuration? Should we instruct users to configure the AWS provider through credentials files or environment variables?
- [x] DNS configuration documentation no longer matches the state of this project. Fix it up.